### PR TITLE
Added matcher with better output than jasmine default

### DIFF
--- a/spec/support/toEqualObject.js
+++ b/spec/support/toEqualObject.js
@@ -1,0 +1,114 @@
+module.exports = {
+  toEqualObject: function(util, customEqualityTesters) {
+    function propertyWithPrefix(prefix, property) {
+      if(prefix) {
+        return prefix + "." + property;
+      }
+      else {
+        return "." + property;
+      }
+    }
+
+    function getObjectDiff(actual, expected, prefix) {
+      var diffs = {}
+
+      for (var property in actual) {
+        if (actual.hasOwnProperty(property)) {
+          if(actual[property] != expected[property]) {
+            var prefixedProperty = propertyWithPrefix(prefix, property);
+
+            if(typeof actual[property] == 'object') {
+              if(typeof expected[property] == 'object') {
+                Object.assign(
+                  diffs,
+                  getObjectDiff(
+                    actual[property],
+                    expected[property],
+                    prefixedProperty
+                  )
+                );
+              }
+              else {
+                diffs[prefixedProperty] = {
+                  expected: expected[property] || null,
+                  actual: JSON.stringify(actual[property])
+                }
+              }
+            }
+            else {
+              diffs[prefixedProperty] = {
+                expected: expected[property] || null,
+                actual: actual[property]
+              }
+            }
+          }
+        }
+      }
+
+      for (var property in expected) {
+        if (expected.hasOwnProperty(property)) {
+          if(actual[property] != expected[property]) {
+            var prefixedProperty = propertyWithPrefix(prefix, property);
+
+            if(diffs[prefixedProperty]) {
+              continue;
+            }
+
+            if(typeof expected[property] == 'object') {
+              if(typeof actual[property] == 'object') {
+                Object.assign(
+                  diffs,
+                  getObjectDiff(
+                    actual[property],
+                    expected[property],
+                    prefixedProperty
+                  )
+                );
+              }
+              else {
+                diffs[prefixedProperty] = {
+                  expected: JSON.stringify(expected[property]),
+                  actual: actual[property] || null
+                }
+              }
+            }
+            else {
+              diffs[prefixedProperty] = {
+                expected: expected[property],
+                actual: actual[property] || null
+              }
+            }
+          }
+        }
+      }
+
+      return diffs;
+    }
+
+    return {
+      compare: function(actual, expected) {
+        const result = {};
+
+        result.pass = util.equals(actual, expected);
+
+        if(result.pass) {
+          result.message = 'Expected objects to not be equal';
+        }
+        else {
+          var diff = getObjectDiff(actual, expected);
+          var message = "Expected objects to be equal. The following properties differ: \n"
+
+          for (var property in diff) {
+            if (diff.hasOwnProperty(property)) {
+              message += "  " + property + "\n    should be: \"" + diff[property].expected + "\"\n    is         \"" + diff[property].actual + "\"\n"
+            }
+          }
+
+          result.message = message;
+        }
+
+        return result;
+      }
+    };
+  }
+}


### PR DESCRIPTION
There's a lot of improvements to make, but should be at least a better start than jasmine's default.

```
var toEqualObject = require('./support/toEqualObject.js');

beforeEach(function(){
  jasmine.addMatchers(toEqualObject);
})

it('does it', function(){
  expect({a: 'a', b: 'b', d: {  }, f: { g: { h: 'h' } }}).toEqualObject({a: 'a', c: 'c', e: { }, f: { g: [1, 2, 3] }});
});
```

produces

<img width="394" alt="screen shot 2017-03-29 at 23 21 04" src="https://cloud.githubusercontent.com/assets/824659/24477284/c3d45a48-14d6-11e7-88e1-fdb6ae99fa16.png">
